### PR TITLE
add endCursor in GetLogs

### DIFF
--- a/example/log_store_sample.go
+++ b/example/log_store_sample.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	sls "go-loghub"
-	"go-loghub/example/util"
+	sls "github.com/galaxydi/go-loghub"
+	"github.com/galaxydi/go-loghub/example/util"
 	"os"
 	"time"
 
@@ -92,8 +92,10 @@ func main() {
 		cursor = c
 		break
 	}
+
+	endCursor, _ := store.GetCursor(0, "end")
 	for {
-		gl, next, err := store.GetLogs(0, cursor, 100)
+		gl, next, err := store.GetLogs(0, cursor, endCursor, 100)
 		if err != nil {
 			fmt.Println("GetLogs from:" + store.Name + " fail:")
 			fmt.Println(err)

--- a/example/util/config.go
+++ b/example/util/config.go
@@ -1,6 +1,6 @@
 package util
 
-import sls "go-loghub"
+import sls "github.com/galaxydi/go-loghub"
 
 // Project define Project for test
 var Project = &sls.LogProject{

--- a/log_store.go
+++ b/log_store.go
@@ -157,10 +157,10 @@ func (s *LogStore) GetCursor(shardID int, from string) (cursor string, err error
 	return
 }
 
-// GetLogsBytes gets logs binary data from shard specified by shardId according cursor.
+// GetLogsBytes gets logs binary data from shard specified by shardId according cursor and endCursor.
 // The logGroupMaxCount is the max number of logGroup could be returned.
 // The nextCursor is the next curosr can be used to read logs at next time.
-func (s *LogStore) GetLogsBytes(shardID int, cursor string,
+func (s *LogStore) GetLogsBytes(shardID int, cursor, endCursor string,
 	logGroupMaxCount int) (out []byte, nextCursor string, err error) {
 
 	h := map[string]string{
@@ -169,8 +169,8 @@ func (s *LogStore) GetLogsBytes(shardID int, cursor string,
 		"Accept-Encoding":   "lz4",
 	}
 
-	uri := fmt.Sprintf("/logstores/%v/shards/%v?type=logs&cursor=%v&count=%v",
-		s.Name, shardID, cursor, logGroupMaxCount)
+	uri := fmt.Sprintf("/logstores/%v/shards/%v?type=logs&cursor=%v&end_cursor=%v&count=%v",
+		s.Name, shardID, cursor, endCursor, logGroupMaxCount)
 
 	r, err := request(s.project, "GET", uri, h, nil)
 	if err != nil {
@@ -245,13 +245,13 @@ func LogsBytesDecode(data []byte) (gl *LogGroupList, err error) {
 	return gl, nil
 }
 
-// GetLogs gets logs from shard specified by shardId according cursor.
+// GetLogs gets logs from shard specified by shardId according cursor end end_cursor.
 // The logGroupMaxCount is the max number of logGroup could be returned.
 // The nextCursor is the next curosr can be used to read logs at next time.
-func (s *LogStore) GetLogs(shardID int, cursor string,
+func (s *LogStore) GetLogs(shardID int, cursor, endCursor string,
 	logGroupMaxCount int) (gl *LogGroupList, nextCursor string, err error) {
 
-	out, nextCursor, err := s.GetLogsBytes(shardID, cursor, logGroupMaxCount)
+	out, nextCursor, err := s.GetLogsBytes(shardID, cursor, endCursor, logGroupMaxCount)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
add parameter 'endcursor' to the API 'GetLogs'